### PR TITLE
Use injected MODULE_PATH

### DIFF
--- a/modules/catalog-web/src/main/resources/META-INF/resources/js/config.js
+++ b/modules/catalog-web/src/main/resources/META-INF/resources/js/config.js
@@ -1,13 +1,9 @@
 ;(function() {
-	var PATH_PRODUCT_ITEM_SELECTOR = Liferay.ThemeDisplay.getPathContext() + '/o/catalog-web';
-
-	
-	
 	AUI().applyConfig(
 		{
 			groups: {
 				product: {
-					base: PATH_PRODUCT_ITEM_SELECTOR + '/js/item_selector/',
+					base: MODULE_PATH + '/js/item_selector/',
 					modules: {
 						'product-item-selector': {
 							path: 'product_item_selector.js',
@@ -17,7 +13,7 @@
 							]
 						}
 					},
-					root: PATH_PRODUCT_ITEM_SELECTOR + '/js/'
+					root: MODULE_PATH + '/js/'
 				}
 			}
 		}


### PR DESCRIPTION
It is a best practice not to hardcode OSGi paths. For this, we now [inject](https://github.com/liferay/liferay-portal/blob/master/modules/apps/foundation/frontend-js/frontend-js-bundle-config-extender/src/main/java/com/liferay/frontend/js/bundle/config/extender/JSBundleConfigServlet.java#L99-L101) the `MODULE_PATH` when printing out the bundle configs, so you can safely reference it like we do in https://github.com/liferay/liferay-portal/blob/master/modules/apps/foundation/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/config.js#L6
